### PR TITLE
Eval extension & fixes

### DIFF
--- a/scripts/evaluation/README.md
+++ b/scripts/evaluation/README.md
@@ -4,7 +4,7 @@ Due to the large number of files that need to be processed the main evaluation i
 - collection of previously generated files into one cached dataframe (parallel) - `collect_stats.jl`
 - printing of summary tables - `evaluate_performance.jl`
 
-The first two steps can be run as a batch job by running `sbatch run_eval.sh` script. By default this won't rewrite any precomputed files with the exception of the cached DataFrame in the second step. 
+The first two steps can be run as a batch job by running `sbatch --output ${HOME}/logs/eval-%J.out run_eval.sh {arg}` script with `images|tabular` argument, specifying which datasets to take into account. By default this won't rewrite any precomputed files with the exception of the cached DataFrame in the second step. 
 
 ```
     julia --threads 16 --project ./generate_stats.jl experiments/images evaluation/images 

--- a/scripts/evaluation/evaluate_performance.jl
+++ b/scripts/evaluation/evaluate_performance.jl
@@ -14,7 +14,7 @@ using GenerativeAD.Evaluation: rank_table, print_rank_table
 
 s = ArgParseSettings()
 @add_arg_table! s begin
-    "filename"
+	"filename"
 		arg_type = String
 		default = "evaluation/images_eval.bson"
 		help = "Location of cached DataFrame."
@@ -47,11 +47,11 @@ end
 
 function aggregate_experiments(df, criterion, metric)
 	std_col = _prefix_symbol(metric, :std)
-    df_agg = aggregate_stats(
-    	df, 
-    	Symbol(criterion), 
-    	[Symbol(metric), std_col, :parameters]; 
-    	undersample=Dict("ocsvm" => 100))
+	df_agg = aggregate_stats(
+		df, 
+		Symbol(criterion), 
+		[Symbol(metric), std_col, :parameters]; 
+		undersample=Dict("ocsvm" => 100))
 
 	df_agg[:, metric] = round.(df_agg[:, metric], digits=2)
 	df_agg[:, std_col] = round.(df_agg[:, std_col], digits=2)

--- a/scripts/evaluation/run_eval.sh
+++ b/scripts/evaluation/run_eval.sh
@@ -6,14 +6,18 @@
 #SBATCH --mem-per-cpu 8G
 #SBATCH --time 4:00:00
 #SBATCH --job-name generativead-eval
-#SBATCH --output eval-%J.out
 #SBATCH --qos==collaborator
 
-module load Julia/1.5.1-linux-x86_64
-module load Python/3.8.2-GCCcore-9.3.0
+DATASETS=$1
+if [ "$DATASETS" == "tabular" ] || [ "$DATASETS" == "images" ]; then
+    module load Julia/1.5.1-linux-x86_64
+    module load Python/3.8.2-GCCcore-9.3.0
 
-source ${HOME}/julia-env/bin/activate
-export PYTHON="${HOME}/julia-env/bin/python"
+    source ${HOME}/julia-env/bin/activate
+    export PYTHON="${HOME}/julia-env/bin/python"
 
-julia --threads 32 --project ./generate_stats.jl experiments/images evaluation/images 
-julia --threads 32 --project ./collect_stats.jl  evaluation/images evaluation/images_eval.bson -f
+    julia --threads 32 --project ./generate_stats.jl experiments/${DATASETS} evaluation/${DATASETS} 
+    julia --threads 32 --project ./collect_stats.jl  evaluation/${DATASETS} evaluation/${DATASETS}_eval.bson -f
+else
+    echo "Unsupported dataset type. Only 'images' or 'tabular' are supported."
+fi

--- a/scripts/evaluation/run_eval.sh
+++ b/scripts/evaluation/run_eval.sh
@@ -12,7 +12,6 @@
 module load Julia/1.5.1-linux-x86_64
 module load Python/3.8.2-GCCcore-9.3.0
 
-# load virtualenv
 source ${HOME}/julia-env/bin/activate
 export PYTHON="${HOME}/julia-env/bin/python"
 

--- a/src/evaluation/stats.jl
+++ b/src/evaluation/stats.jl
@@ -60,6 +60,9 @@ function compute_stats(f::String)
 		labels = r[_prefix_symbol(splt, :labels)]
 
 		if length(scores) > 1
+			# in cases where scores is not an 1D array
+			scores = scores[:]
+
 			invalid = isnan.(scores)
 			ninvalid = sum(invalid)
 
@@ -73,9 +76,6 @@ function compute_stats(f::String)
 				labels = labels[.~invalid]
 				(invrat > 0.5) && error("$(splt)_scores contain too many NaN")
 			end
-			
-			# in cases where the score is not 1D array
-			scores = scores[:]
 
 			roc = EvalMetrics.roccurve(labels, scores)
 			auc = EvalMetrics.auc_trapezoidal(roc...)

--- a/src/evaluation/stats.jl
+++ b/src/evaluation/stats.jl
@@ -119,7 +119,9 @@ columns of different types
 When nonempty `downsample` dictionary is specified, the entries of`("model" => #samples)`, specify
 how many samples should be taken into acount. These are selected randomly with fixed seed.
 """
-function aggregate_stats(df::DataFrame, criterion_col=:val_auc; downsample=Dict("ocsvm" => 100))
+function aggregate_stats(df::DataFrame, criterion_col=:val_auc; 
+							min_samples=("anomaly_class" in names(df)) ? 30 : 3, 
+							downsample=Dict("ocsvm" => 100))
 	agg_cols = vcat(_prefix_symbol.("val", BASE_METRICS), _prefix_symbol.("tst", BASE_METRICS))
 	agg_cols = vcat(agg_cols, _prefix_symbol.("val", PAT_METRICS), _prefix_symbol.("tst", PAT_METRICS))
 
@@ -137,8 +139,7 @@ function aggregate_stats(df::DataFrame, criterion_col=:val_auc; downsample=Dict(
 			
 			# filter only those hyperparameter that have sufficient number of samples
 			# with images at least 3*10 otherwise 3
-			threshold = ("anomaly_class" in names(df)) ? 30 : 3
-			mg_suff = reduce(vcat, [g for g in pg if nrow(g) >= threshold])
+			mg_suff = reduce(vcat, [g for g in pg if nrow(g) >= min_samples])
 			
 			# for some methods and threshold the data frame is empty
 			if nrow(mg_suff) > 0


### PR DESCRIPTION
- [x] adding argument for `run_eval` script

- [x] adding std over top 10  hyperparameters

- [x] adding threshold on number of seed/anomaly_class samples per given hyperparameter

- [x] fix: undersampling fails on image data due to `ocsvm` having the same name as for tabular data

- [x] add arg modelkey to group on - allow for grouping models into groups such as classical, flows, autoencoders, ... **is not part of this pull request as it can be done with the current code, just not as nicely**
