### PR TITLE
Add max_mean aggregation to evaluation.

### DIFF
--- a/scripts/evaluation/evaluate_performance.jl
+++ b/scripts/evaluation/evaluate_performance.jl
@@ -9,7 +9,7 @@ using DataFrames
 using PrettyTables
 using PrettyTables.Crayons
 
-using GenerativeAD.Evaluation: _prefix_symbol, PAT_METRICS, aggregate_stats
+using GenerativeAD.Evaluation: _prefix_symbol, PAT_METRICS, aggregate_stats_mean_max
 using GenerativeAD.Evaluation: rank_table, print_rank_table
 
 s = ArgParseSettings()
@@ -54,12 +54,12 @@ function main(args)
 		ranks = []
 		if args["rank-metric"] != ""
 			for criterion in _prefix_symbol.("val", PAT_METRICS)
-				df_agg = aggregate_stats(df, criterion)
+				df_agg = aggregate_stats_mean_max(df, criterion)
 				push!(ranks, rank_table(df_agg, args["rank-metric"])[end:end, :])
 			end
 		else # pat/pat scenario if no rank-metric is provided
 			for (criterion, metric) in zip(_prefix_symbol.("val", PAT_METRICS), _prefix_symbol.("tst", PAT_METRICS))
-				df_agg = aggregate_stats(df, criterion)
+				df_agg = aggregate_stats_mean_max(df, criterion)
 				push!(ranks, rank_table(df_agg, metric)[end:end, :])
 			end
 		end
@@ -94,7 +94,7 @@ function main(args)
 				)
 		end
 	else
-		df_agg = aggregate_stats(df, Symbol(args["criterion-metric"]))
+		df_agg = aggregate_stats_mean_max(df, Symbol(args["criterion-metric"]))
 		rt = rank_table(df_agg, args["rank-metric"])
 
 		@info "Best models chosen by $(args["criterion-metric"])"

--- a/scripts/evaluation/run_eval.sh
+++ b/scripts/evaluation/run_eval.sh
@@ -13,9 +13,6 @@ if [ "$DATASETS" == "tabular" ] || [ "$DATASETS" == "images" ]; then
     module load Julia/1.5.1-linux-x86_64
     module load Python/3.8.2-GCCcore-9.3.0
 
-    source ${HOME}/julia-env/bin/activate
-    export PYTHON="${HOME}/julia-env/bin/python"
-
     julia --threads 32 --project ./generate_stats.jl experiments/${DATASETS} evaluation/${DATASETS} 
     julia --threads 32 --project ./collect_stats.jl  evaluation/${DATASETS} evaluation/${DATASETS}_eval.bson -f
 else

--- a/scripts/evaluation/synchronize_stats.jl
+++ b/scripts/evaluation/synchronize_stats.jl
@@ -1,0 +1,60 @@
+using ArgParse
+using DrWatson
+@quickactivate
+using GenerativeAD
+
+s = ArgParseSettings()
+@add_arg_table! s begin
+    "exp_prefix"
+		arg_type = String
+		default = "experiments/tabular"
+		help = "Data prefix of experiment files."
+	"eval_prefix"
+		arg_type = String
+		default = "evaluation/tabular"
+		help = "Data prefix of evaluation files."
+	"-d", "--dry_run"
+    	action = :store_true
+		help = "Compute diff but do not delete."
+end
+
+"""
+	synchronize_stats(exp_prefix::String, eval_prefix::String; dry_run=false)
+
+Collects filesnames from evaluation datadir in `eval_prefix` and compares it to
+contents of experiments in `exp_prefix` datadir. If `dry_run` is true the function does
+not delete the evaluation files for which there are no longer experiment files.
+"""
+function synchronize_stats(exp_prefix::String, eval_prefix::String; dry_run=false)
+    exp_dir = datadir(exp_prefix)
+    eval_dir = datadir(eval_prefix)
+    
+    @info "Collecting files from $exp_dir and $eval_dir folders."
+    exp_files = GenerativeAD.Evaluation.collect_files(exp_dir)
+    filter!(x -> !startswith(basename(x), "model"), exp_files)
+    eval_files = GenerativeAD.Evaluation.collect_files(eval_dir)
+    
+    @info "Collected $(length(exp_files)) files from experiment folder."
+    @info "Collected $(length(eval_files)) files from evaluation folder."
+    
+    # reverse naming of exp files to evaluation
+    exp_eval_files = joinpath.(dirname.(exp_files), "eval_" .* basename.(exp_files))
+    exp_eval_files = replace.(exp_eval_files, exp_prefix => eval_prefix)
+
+    dif = setdiff(eval_files, exp_eval_files)
+    @info "$(length(dif)) evaluation files lack underlying experiment files."
+    
+    if !dry_run
+        @info "Removing files."
+        rm.(dif)
+    end
+end
+
+
+function main(args)
+    @unpack exp_prefix, eval_prefix, dry_run = args
+	synchronize_stats(exp_prefix, eval_prefix; dry_run=dry_run)
+	@info "---------------- DONE -----------------"
+end
+
+main(parse_args(ARGS, s))

--- a/src/evaluation/show.jl
+++ b/src/evaluation/show.jl
@@ -63,7 +63,7 @@ function rank_table(df::DataFrame, metric_col=:tst_auc)
 	for row in eachrow(rt[1:end-2,:])
 		rs .+= StatsBase.competerank(mask_nan_max.(Vector(row[2:end])), rev = true)
 	end
-	rs ./= size(rt, 1)
+	rs ./= (size(rt, 1) - 2)
 	rs = round.(rs, digits=2)
 	push!(rt, ["RANK", rs...])
 

--- a/src/evaluation/show.jl
+++ b/src/evaluation/show.jl
@@ -64,7 +64,7 @@ function rank_table(df::DataFrame, metric_col=:tst_auc)
 		rs .+= StatsBase.competerank(mask_nan_max.(Vector(row[2:end])), rev = true)
 	end
 	rs ./= (size(rt, 1) - 2)
-	rs = round.(rs, digits=2)
+	rs = round.(rs, digits=1)
 	push!(rt, ["RANK", rs...])
 
 	rt
@@ -92,13 +92,16 @@ function print_rank_table(io::IO, rt::DataFrame; backend=:txt)
 	# highlight minimum rank in last row
 	f_hl_best_rank = (data, i, j) -> i == size(rt, 1) && (data[i,j] == minimum(rt[i, 2:end]))	
 
+	# format metrics to 2 digits and rank to 1
+	f_float = (v, i, j) -> (i == size(rt, 1)) ? ft_printf("%.1f")(v,i,j) : ft_printf("%.2f")(v,i,j)
+
 	if backend == :html
 		hl_best = HTMLHighlighter(f_hl_best, HTMLDecoration(color = "blue", font_weight = "bold"))
 		hl_best_rank = HTMLHighlighter(f_hl_best_rank, HTMLDecoration(color = "red", font_weight = "bold"))
 
 		pretty_table(
 			io,	rt,
-			formatters=ft_round(2),
+			formatters=f_float,
 			highlighters=(hl_best, hl_best_rank),
 			nosubheader=true,
 			tf=html_minimalist
@@ -110,7 +113,7 @@ function print_rank_table(io::IO, rt::DataFrame; backend=:txt)
 		pretty_table(
 			io,	rt, 
 			backend=:latex,
-			formatters=ft_round(2),
+			formatters=f_float,
 			highlighters=(hl_best, hl_best_rank),
 			hlines=hlines
 		)
@@ -120,7 +123,7 @@ function print_rank_table(io::IO, rt::DataFrame; backend=:txt)
 
 		pretty_table(
 			io, rt,
-			formatters=ft_round(2),
+			formatters=f_float,
 			highlighters=(hl_best, hl_best_rank),
 			body_hlines=hlines
 		)

--- a/src/evaluation/stats.jl
+++ b/src/evaluation/stats.jl
@@ -118,6 +118,8 @@ columns of different types
 	+ `dsamples_valid` - number of sampled hyperparameters with enough runs
 When nonempty `downsample` dictionary is specified, the entries of`("model" => #samples)`, specify
 how many samples should be taken into acount. These are selected randomly with fixed seed.
+Optional arg `min_samples` specifies how many seed/anomaly_class combinations should be present
+in order for the hyperparameter's results be considered statistically significant.
 """
 function aggregate_stats(df::DataFrame, criterion_col=:val_auc; 
 							min_samples=("anomaly_class" in names(df)) ? 30 : 3, 
@@ -169,4 +171,71 @@ function aggregate_stats(df::DataFrame, criterion_col=:val_auc;
 		end
 	end
 	vcat(results...)
+end
+
+
+"""
+aggregate_stats_max_mean(df::DataFrame, criterion_col=:val_auc; undersample=Dict("ocsvm" => 100))
+
+Chooses the best hyperparameters for each seed/anomaly_class combination by `criterion_col`
+and then aggregates the metrics over seed/anomaly_class to get the final results. The output 
+is a DataFrame of maximum #datasets*#models rows with
+columns of different types
+- identifiers - `dataset`, `modelname`, `phash`, `parameters`
+- averaged metrics - both from test and validation data such as `tst_auc`, `val_pat_10`, etc.
+- std of best hyperparameter computed for each metric over different seeds, suffixed `_std`
+- std of best 10 hyperparameters computed over averaged metrics, suffixed `_top_10_std`
+- samples involved in the aggregation, 
++ `psamples` - number of runs of the best hyperparameter
++ `dsamples` - number of sampled hyperparameters
++ `dsamples_valid` - number of sampled hyperparameters with enough runs
+When nonempty `downsample` dictionary is specified, the entries of`("model" => #samples)`, specify
+how many samples should be taken into acount. These are selected randomly with fixed seed.
+TODO: Optional arg `min_samples` specifies how many seed/anomaly_class combinations should be present
+in order for the hyperparameter's results be considered statistically significant.
+"""
+function aggregate_stats_max_mean(df::DataFrame, criterion_col=:val_auc; 
+                        min_samples=("anomaly_class" in names(df)) ? 30 : 3, 
+                        downsample=Dict("ocsvm" => 100))
+agg_cols = vcat(_prefix_symbol.("val", BASE_METRICS), _prefix_symbol.("tst", BASE_METRICS))
+agg_cols = vcat(agg_cols, _prefix_symbol.("val", PAT_METRICS), _prefix_symbol.("tst", PAT_METRICS))
+top10_std_cols = _prefix_symbol.(agg_cols, "top_10_std")
+
+agg_keys = ("anomaly_class" in names(df)) ? [:seed, :anomaly_class] : [:seed]
+# choose best for each seed/anomaly_class cobination and average over them
+results = []
+for (dkey, dg) in pairs(groupby(df, :dataset))
+    for (mkey, mg) in pairs(groupby(dg, :modelname))
+        partial_results = []
+        for (skey, sg) in pairs(groupby(mg, agg_keys))
+            # @info "$(dkey.dataset) - $(mkey.modelname) - $(skey)"
+            n = nrow(sg)
+            Random.seed!(42)
+            ssg = (mkey.modelname in keys(downsample)) && (downsample[mkey.modelname] < n) ? 
+                    sg[randperm(n)[1:downsample[mkey.modelname]], :] : sg
+            Random.seed!()
+            
+            sssg = sort(ssg, order(criterion_col, rev=true))
+            best = first(sssg, 1)
+            
+            best_10_std = combine(first(sssg, 10), agg_cols .=> std .=> top10_std_cols)
+            best = hcat(best, best_10_std)
+            
+            push!(partial_results, best)
+        end
+
+        best_per_seed = reduce(vcat, partial_results)
+        best = combine(best_per_seed, 
+                    nrow => :psamples, 
+                    agg_cols .=> mean .=> agg_cols, 
+                    top10_std_cols .=> mean .=> top10_std_cols,
+                    agg_cols .=> std) 
+        
+        best[:dataset] = dkey.dataset
+        best[:modelname] = mkey.modelname
+    
+        push!(results, best)
+    end
+end
+vcat(results...)
 end


### PR DESCRIPTION
- [x] initial draft

- [x] check if output is correct

- [x] ~~criteria on number of samples/repetition, i.e. implement `min_samples`~~ does not make much sense in max-mean aggr

- [x] ~~modify `evaluate_performance` script to take this new aggregation into account~~ exposed only the default mean-max method