### PR TITLE
DAGMM

### DIFF
--- a/scripts/experiments_tabular/dagmm.jl
+++ b/scripts/experiments_tabular/dagmm.jl
@@ -28,26 +28,21 @@ modelname = "dagmm"
 
 function sample_params()
     parameter_rng = (
-        zdim 		= 2 .^(0:2),
+        zdim 		= 2 .^(0:1),
         hdim 		= 2 .^(1:8),
         nlayers 	= 2:3,
         ncomp       = 2:8,
-        lambda_rat 	= 1:2:9,
+        lambda_e 	= [1.0, 0.5, 0.1],
+        lambda_d    = [1.0, 0.5, 0.1, 0.05, 0.005],
         lr 			= [1f-3, 1f-4, 1f-5],
         batchsize 	= 2 .^ (5:8),
         activation	= ["tanh"],
         dropout		= 0.0:0.1:0.5,
-        wreg 		= [0.0, 1f-5, 1f-6],
+        wreg 		= [0.0],
         init_seed 	= 1:Int(1e8),
     )
-    parameters = (;zip(keys(parameter_rng), map(x->sample(x, 1)[1], parameter_rng))...)
-    
-    # ensure that zdim < hdim, even though zdim is usually small
-    while parameters.zdim >= parameters.hdim
-        @info "zdim $(parameters.zdim) too large in combination with hdim $(parameters.hdim)"
-		parameters = merge(parameters, (;zdim = sample(parameter_rng.zdim)))
-	end
-    parameters
+
+    (;zip(keys(parameter_rng), map(x->sample(x, 1)[1], parameter_rng))...)
 end
 
 function fit(data, parameters)

--- a/scripts/experiments_tabular/dagmm.jl
+++ b/scripts/experiments_tabular/dagmm.jl
@@ -32,7 +32,7 @@ function sample_params()
         hdim 		= 2 .^(1:8),
         nlayers 	= 2:3,
         ncomp       = 2:8,
-        lambda_rat 	= 1:9,
+        lambda_rat 	= 1:2:9,
         lr 			= [1f-3, 1f-4, 1f-5],
         batchsize 	= 2 .^ (5:8),
         activation	= ["tanh"],

--- a/scripts/experiments_tabular/dagmm.jl
+++ b/scripts/experiments_tabular/dagmm.jl
@@ -1,0 +1,119 @@
+using DrWatson
+@quickactivate
+using ArgParse
+using GenerativeAD
+using StatsBase: fit!, predict, sample
+using BSON
+using Flux
+
+s = ArgParseSettings()
+@add_arg_table! s begin
+    "max_seed"
+        default = 1
+        arg_type = Int
+        help = "maximum number of seeds to run through"
+    "dataset"
+        default = "iris"
+        arg_type = String
+        help = "dataset"
+    "contamination"
+        arg_type = Float64
+        help = "contamination rate of training data"
+        default = 0.0
+end
+parsed_args = parse_args(ARGS, s)
+@unpack dataset, max_seed, contamination = parsed_args
+
+modelname = "dagmm"
+
+function sample_params()
+    parameter_rng = (
+        zdim 		= 2 .^(0:2),
+        hdim 		= 2 .^(1:8),
+        nlayers 	= 1:3,
+        ncomp       = 2:8,
+        lambda_rat 	= 1:9,
+        lr 			= [1f-3, 1f-4, 1f-5],
+        batchsize 	= 2 .^ (5:8),
+        activation	= ["tanh"],
+        dropout		= 0.0:0.1:0.5,
+        wreg 		= [0.0, 1f-5, 1f-6],
+        init_seed 	= 1:Int(1e8),
+    )
+
+    (;zip(keys(parameter_rng), map(x->sample(x, 1)[1], parameter_rng))...)
+end
+
+function fit(data, parameters)
+    model = GenerativeAD.Models.DAGMM(;idim=size(data[1][1], 1), parameters...)
+
+    try
+        global info, fit_t, _, _, _ = @timed fit!(model, data; max_train_time=82800/max_seed, 
+                        patience=200, check_interval=1, parameters...)
+    catch e
+        @info "Failed training due to \n$e"
+        return (fit_t = NaN, history=nothing, npars=nothing, model=nothing), []
+    end
+
+    training_info = (
+        fit_t = fit_t,
+        history = info.history,
+        niter = info.niter,
+        npars = info.npars,
+        model = info.model
+        )
+
+    # compute mixture parameters from the whole training data
+    testmode!(model, true)
+    _, _, z, gamma = model(data[1][1])
+    phi, mu, cov = GenerativeAD.Models.compute_params(z, gamma)
+    testmode!(model, false)
+
+    # this will have to store the parameters obtained from clean data
+    training_info, [(x -> predict(info.model, x, phi, mu, cov), parameters)]
+end
+
+
+try_counter = 0
+max_tries = 10*max_seed
+cont_string = (contamination == 0.0) ? "" : "_contamination-$contamination"
+while try_counter < max_tries
+    parameters = sample_params()
+
+    for seed in 1:max_seed
+        savepath = datadir("experiments/tabular$cont_string/$(modelname)/$(dataset)/seed=$(seed)")
+        mkpath(savepath)
+
+        # get data
+        data = GenerativeAD.load_data(dataset, seed=seed, contamination=contamination)
+        edited_parameters = GenerativeAD.edit_params(data, parameters)
+
+        if GenerativeAD.check_params(savepath, edited_parameters)
+            @info "Started training $(modelname)$(edited_parameters) on $(dataset):$(seed)"
+            @info "Train/valdiation/test splits: $(size(data[1][1], 2)) | $(size(data[2][1], 2)) | $(size(data[2][1], 2))"
+            @info "Number of features: $(size(data[1][1], 1))"
+            
+            training_info, results = fit(data, edited_parameters)
+
+            if training_info.model != nothing
+                tagsave(joinpath(savepath, savename("model", edited_parameters, "bson", digits=5)), 
+                        Dict("model"=>training_info.model,
+                            "fit_t"=>training_info.fit_t,
+                            "history"=>training_info.history,
+                            "parameters"=>edited_parameters
+                            ), safe = true)
+                training_info = merge(training_info, (model = nothing,))
+            end
+            save_entries = merge(training_info, (modelname = modelname, seed = seed, dataset = dataset, contamination = contamination))
+
+            for result in results
+                GenerativeAD.experiment(result..., data, savepath; save_entries...)
+            end
+            global try_counter = max_tries + 1
+        else
+            @info "Model already present, trying new hyperparameters..."
+            global try_counter += 1
+        end
+    end
+end
+(try_counter == max_tries) ? (@info "Reached $(max_tries) tries, giving up.") : nothing

--- a/scripts/experiments_tabular/dagmm.jl
+++ b/scripts/experiments_tabular/dagmm.jl
@@ -85,7 +85,7 @@ function GenerativeAD.edit_params(data, parameters)
 	# set hdim ~ idim/2 if hdim >= idim
 	if parameters.hdim >= idim
 		hdims = 2 .^(1:8)
-		hdim_new = hdims[hdims .< idim//2][end]
+		hdim_new = hdims[hdims .<= (idim+1)//2][end]
         @info "Lowering width of autoencoder $(parameters.hdim) -> $(hdim_new)"
 		parameters = merge(parameters, (hdim=hdim_new,))
 	end

--- a/scripts/experiments_tabular/dagmm_run.sh
+++ b/scripts/experiments_tabular/dagmm_run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#SBATCH --time=24:00:00
+#SBATCH --nodes=1 --ntasks-per-node=4 --cpus-per-task=1
+#SBATCH --mem=24G
+#SBATCH --qos==collaborator
+
+MAX_SEED=$1
+DATASET=$2
+CONTAMINATION=$3
+
+module load Julia/1.5.3-linux-x86_64
+module load Python/3.8.2-GCCcore-9.3.0
+
+julia --project -e 'using Pkg; Pkg.instantiate();'
+
+julia --project ./dagmm.jl $MAX_SEED $DATASET $CONTAMINATION

--- a/scripts/experiments_tabular/dagmm_run.sh
+++ b/scripts/experiments_tabular/dagmm_run.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+#SBATCH --partition=cpu
 #SBATCH --time=24:00:00
-#SBATCH --nodes=1 --ntasks-per-node=4 --cpus-per-task=1
-#SBATCH --mem=24G
+#SBATCH --nodes=1 --cpus-per-task=1
+#SBATCH --mem=16G
 #SBATCH --qos==collaborator
 
 MAX_SEED=$1

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -33,6 +33,7 @@ include("fanogan.jl")
 include("gan.jl")
 include("sptn.jl")
 include("loda.jl")
+include("dagmm.jl")
 
 # this contains dependencies from vae and aae
 include("utils/vae_utils.jl")

--- a/src/models/dagmm.jl
+++ b/src/models/dagmm.jl
@@ -1,3 +1,13 @@
+"""
+    Implements all needed parts for constructing DAGMM model
+        (https://sites.cs.ucsb.edu/~bzong/doc/iclr18-dagmm.pdf) for detecting anomalies.
+    Code is inspired by multiple reimplementations
+    - https://github.com/danieltan07/dagmm
+    - https://github.com/tnakae/DAGMM/
+    - https://github.com/Newcomer520/tf-dagmm
+    - https://github.com/mperezcarrasco/PyTorch-DAGMM
+"""
+
 using Flux: mse, softmax, unsqueeze, stack
 using LinearAlgebra
 using StatsBase

--- a/src/models/dagmm.jl
+++ b/src/models/dagmm.jl
@@ -4,6 +4,7 @@ using StatsBase
 using Statistics
 using Distributions
 using DistributionsAD
+using MLDataPattern: RandomBatches
 
 struct DAGMM{E,D,S}
     encoder::E
@@ -95,7 +96,7 @@ function compute_params(z, gamma)
     phi, mu, cov
 end
 
-function compute_energy(z, phi, mu, cov; eps=1e-12)
+function compute_energy(z, phi, mu, cov; eps=1e-7)
     T = eltype(z)
     z_mu = unsqueeze(z,2) .- mu
     D, K, _ = size(mu)

--- a/src/models/dagmm.jl
+++ b/src/models/dagmm.jl
@@ -163,15 +163,11 @@ function StatsBase.fit!(model::DAGMM, data::Tuple; max_train_time=82800,
     for batch in RandomBatches(X, batchsize)
         batch_loss = 0f0
 
-        grad_time = try 
-            @elapsed begin
-                gs = gradient(() -> begin 
-                    batch_loss = loss(trn_model, batch, λ₁, λ₂)
-                end, ps)
-                Flux.update!(opt, ps, gs)
-            end
-        catch
-            return trn_model, batch
+        grad_time = @elapsed begin
+            gs = gradient(() -> begin 
+                batch_loss = loss(trn_model, batch, λ₁, λ₂)
+            end, ps)
+            Flux.update!(opt, ps, gs)
         end
 
         push!(history, :batch_loss, i, batch_loss)

--- a/src/models/dagmm.jl
+++ b/src/models/dagmm.jl
@@ -1,0 +1,211 @@
+using Flux: mse, softmax, unsqueeze, stack
+using LinearAlgebra
+using StatsBase
+using Statistics
+using Distributions
+using DistributionsAD
+
+struct DAGMM{E,D,S}
+    encoder::E
+    decoder::D
+    estimator::S
+end
+
+Flux.@functor DAGMM
+
+function DAGMM(;idim::Int=1, activation="tanh", hdim=60, zdim=1, ncomp=2, 
+        nlayers::Int=3, dropout=0.5, init_seed=nothing, kwargs...)
+    # if seed is given, set it
+    (init_seed !== nothing) ? Random.seed!(init_seed) : nothing
+
+    encoder = build_mlp(idim, hdim, zdim, nlayers, activation=activation, lastlayer="linear")
+    decoder = build_mlp(zdim, hdim, idim, nlayers, activation=activation, lastlayer="linear")
+    estimator = build_mlp(zdim+2, hdim, ncomp, nlayers, activation=activation, lastlayer="linear")
+    
+    if dropout > 0.0
+        estimator = Chain(estimator[1:end-1]..., Dropout(dropout), estimator[end])
+    end
+
+    # reset seed
+    (init_seed !== nothing) ? Random.seed!() : nothing
+
+    DAGMM(encoder, decoder, estimator)
+end
+
+function Base.show(io::IO, model::DAGMM)
+    # to avoid the show explosion
+    print(io, "DAGMM(...)")
+end
+
+norm2(x; dims=1) = sqrt.(sum(abs2, x; dims=dims))
+
+function cosine_similarity(x₁, x₂; dims=1, eps=1e-8)
+    T = eltype(x₁)
+    nx₁ = norm2(x₁; dims=dims)
+    nx₂ = norm2(x₂; dims=dims)
+    sum(x₁ .* x₂; dims=dims) ./ max.(nx₁ .* nx₂, T(eps))
+end
+
+function compute_reconstruction(x, x̂)
+    relrec = norm2(x .- x̂; dims=1) ./ norm2(x; dims=1)
+    cosim = cosine_similarity(x, x̂; dims=1)
+    relrec, cosim
+end
+
+function (model::DAGMM)(x)
+    z_c = model.encoder(x)
+    x̂ = model.decoder(z_c)
+    rec_1, rec_2 = compute_reconstruction(x, x̂)
+    z = cat([z_c, rec_1, rec_2]..., dims=1)
+    gamma = softmax(model.estimator(z))
+    z_c, x̂, z, gamma
+end
+
+
+"""
+Computing the parameters phi, mu and gamma for sample energy function 
+
+K: number of Gaussian mixture components
+N: Number of samples
+D: Latent dimension
+
+z = DxN
+gamma = KxN
+
+this will be a little bit different in Julia
+""" 
+function compute_params(z, gamma)
+    #phi = D
+    gamma_sum = sum(gamma; dims=2)
+    phi = gamma_sum ./ size(gamma, 2)
+
+    #mu = D x K x 1
+    mu = sum(unsqueeze(gamma,1) .* unsqueeze(z,2); dims=3) ./ gamma_sum'
+
+    # z_mu = D x K x N
+    z_mu = unsqueeze(z,2) .- mu
+    
+    # z_mu = D x D x K x N
+    z_mu_z_mu_t = unsqueeze(z_mu, 2) .* unsqueeze(z_mu, 1)
+    
+    #cov = K x D x D
+    cov = sum(unsqueeze(unsqueeze(gamma, 1), 1) .* z_mu_z_mu_t; dims=4)
+    cov = dropdims(cov; dims=4) ./ unsqueeze(gamma_sum', 1)
+
+    phi, mu, cov
+end
+
+function compute_energy(z, phi, mu, cov; eps=1e-12)
+    T = eltype(z)
+    z_mu = unsqueeze(z,2) .- mu
+    D, K, _ = size(mu)
+
+    cov = cov .+ Diagonal(ones(Float32, D) .* T(eps))
+  
+    cov_inverse = stack([inv(cov[:,:,k]) for k in 1:K], 3)
+    det_cov = unsqueeze(unsqueeze([det(cov[:,:,k] .* 2 * T.(π)) for k in 1:K],1),1)
+    cov_diag = sum([sum(1 ./ diag(cov[:,:,k])) for k in 1:K])
+
+    E_z = -T(0.5) .* sum(sum(unsqueeze(z_mu, 1) .* cov_inverse, dims=2) .* unsqueeze(z_mu, 2), dims=1)
+    E_z = exp.(E_z)
+    E_z = -log.(sum(unsqueeze(phi', 1).* E_z ./ sqrt.(det_cov), dims=3).+ T(eps))
+          
+    E_z, cov_diag
+end
+
+
+function loss(model::DAGMM, x, λ₁, λ₂)
+    _, x̂, z, gamma = model(x)
+    reconst_loss = mse(x, x̂)
+    phi, mu, cov = compute_params(z, gamma)
+    sample_energy, cov_diag = compute_energy(z, phi, mu, cov)
+    reconst_loss + λ₁ * mean(sample_energy) + λ₂ * cov_diag
+end
+
+# during testing we use params fitted from training
+# testmode is not really necessary because dropout is not part if the autoencoder
+function StatsBase.predict(model::DAGMM, x, phi, mu, cov)
+    testmode!(model, true)
+    _, _, z, _ = model(x)
+    testmode!(model, false)
+    compute_energy(z, phi, mu, cov)[1]
+end
+
+
+function StatsBase.fit!(model::DAGMM, data::Tuple; max_train_time=82800,
+                        batchsize=64, patience=200, check_interval::Int=1, 
+                        wreg=1f-6, lambda_rat=1, lr=1f-4, kwargs...)
+    # add regularization through weight decay in optimizer
+    opt = (wreg > 0) ? ADAMW(lr, (0.9, 0.999), wreg) : Flux.ADAM(lr)
+    
+    trn_model = deepcopy(model)
+    ps = Flux.params(trn_model);
+
+    X = data[1][1]
+    # filter only normal data from validation set
+    X_val = data[2][1][:, data[2][2] .== 0.0f0]
+
+    # hardcoded parameters, changing only the ratios
+    λ₁, λ₂ = 0.1f0 * lambda_rat, 0.005f0 * lambda_rat
+
+    history = MVHistory()
+    _patience = patience
+    
+    best_val_loss = Inf
+    i = 1
+    start_time = time()
+    frmt(v) = round(v, digits=4)
+    for batch in RandomBatches(X, batchsize)
+        batch_loss = 0f0
+
+        grad_time = @elapsed begin
+            gs = gradient(() -> begin 
+                batch_loss = loss(trn_model, batch, λ₁, λ₂)
+            end, ps)
+            Flux.update!(opt, ps, gs)
+        end
+
+        push!(history, :batch_loss, i, batch_loss)
+        push!(history, :grad_time, i, grad_time)
+
+        if (i%check_interval == 0)
+            testmode!(trn_model, true)
+            val_loss_time = @elapsed val_loss = loss(trn_model, X_val, λ₁, λ₂)
+            testmode!(trn_model, false)
+
+            @info "$i - loss: $(frmt(batch_loss)) (batch) | $(frmt(val_loss)) (validation) || $(frmt(grad_time)) (t_grad) | $(frmt(val_loss_time)) (t_val)"
+            
+            if isnan(val_loss) || isinf(val_loss) || isnan(batch_loss) || isinf(batch_loss)
+                @info "Stopped training after $(i) iterations, $((time() - start_time)/3600) hours due to invalid values."
+                error("Encountered invalid values in loss function.")
+            end
+
+            push!(history, :validation_loss, i, val_loss)
+            push!(history, :val_loss_time, i, val_loss_time)
+
+            if val_loss < best_val_loss
+                best_val_loss = val_loss
+                _patience = patience
+
+                model = deepcopy(trn_model)
+            else # else stop if the model has not improved for `patience` iterations
+                _patience -= 1
+                if _patience == 0
+                    @info "Stopped training after $(i) iterations, $((time() - start_time)/3600) hours."
+                    break
+                end
+            end
+        end
+        
+        # time limit for training
+        if time() - start_time > max_train_time
+            @info "Stopped training after $(i) iterations, $((time() - start_time)/3600) hours due to time constraints."
+            model = deepcopy(trn_model)
+            break
+        end
+
+        i += 1
+    end
+
+    (history=history, niter=i, model=model, npars=sum(map(p->length(p), ps)))
+end

--- a/test/models/dagmm.jl
+++ b/test/models/dagmm.jl
@@ -1,0 +1,118 @@
+###
+# using Revise
+###
+using DrWatson
+using GenerativeAD
+using StatsBase: fit!, predict, sample
+using Statistics
+using BSON
+using Flux
+using NPZ
+using Random
+
+parameters = (
+    lambda_rat 	= 1,
+    lr 			= 1f-4,
+    batchsize 	= 1024,
+    wreg 		= 0.0,
+)
+
+# loading KDDCUP data from npz file
+file = datadir("kdd_cup.npz") # taken from https://github.com/mperezcarrasco/PyTorch-DAGMM
+pydata = NPZ.npzread(file)
+
+labels = pydata["kdd"][:, end];
+features = copy(pydata["kdd"][:, 1:end-1]')
+
+normal_data = features[:, labels .== 0];
+anomalous_data = features[:, labels .== 1];
+
+# split data with fixed seed
+data = GenerativeAD.Datasets.train_val_test_split(normal_data, anomalous_data; seed=1)
+idim = size(data[1][1], 1)
+
+# when running in batch randomize model seed (reset after training - deterministic random batches)
+model_seed = rand(1:1000)
+Random.seed!(model_seed);
+encoder = Chain(Dense(idim, 60, tanh), Dense(60, 30, tanh), Dense(30, 10, tanh), Dense(10, 1))
+decoder = Chain(Dense(1, 10, tanh), Dense(10, 30, tanh), Dense(30, 60, tanh), Dense(60, idim))
+estimator = Chain(Dense(3, 10, tanh), Dropout(0.5), Dense(10, 4))
+
+model = GenerativeAD.Models.DAGMM(encoder, decoder, estimator)
+info, fit_t, _, _, _ = @timed fit!(model, data; patience=20, check_interval=10, parameters...)
+Random.seed!()
+
+trained_model = info.model
+
+testmode!(trained_model, true)
+_, _, z, gamma = trained_model(data[1][1])
+phi, mu, cov = GenerativeAD.Models.compute_params(z, gamma)
+testmode!(trained_model, false)
+
+trn_scores = predict(trained_model, data[1][1], phi, mu, cov);
+val_scores = predict(trained_model, data[2][1], phi, mu, cov);
+tst_scores = predict(trained_model, data[3][1], phi, mu, cov);
+
+using EvalMetrics: ConfusionMatrix, recall, precision, f1_score, roccurve, auc_trapezoidal
+
+# test only
+threshold = quantile(vcat(trn_scores, val_scores, tst_scores), 0.8)
+# threshold = quantile(vcat(trn_scores, val_scores), 0.8)
+
+tst_ŷ = tst_scores .> threshold;
+cm = ConfusionMatrix(data[3][2], tst_ŷ)
+rec, prc, f1s = recall(cm), precision(cm), f1_score(cm)
+
+roc = roccurve(data[3][2], tst_scores)
+auc = auc_trapezoidal(roc)
+
+
+# test + validation
+# val_ŷ = val_scores .> threshold;
+# cm = ConfusionMatrix(vcat(data[2][2], data[3][2]), vcat(val_ŷ, tst_ŷ))
+# recall(cm), precision(cm), f1_score(cm)
+
+results = Dict(
+    :history    => info.history,
+    :niter      => info.niter,
+    :model      => info.model,
+    :recall     => rec,
+    :precision  => prc,
+    :f1         => f1s,
+    :auc        => auc,
+    :phi        => phi, 
+    :mu         => mu,
+    :cov        => cov,
+    :threshold  => threshold,
+    :trn_scores => trn_scores,
+    :trn_labels => data[1][2],
+    :val_scores => val_scores,
+    :val_labels => data[2][2],
+    :tst_scores => tst_scores,
+    :tst_labels => data[3][2]
+)
+
+@info("", model_seed, threshold, rec, prc, f1s, auc)
+
+save(datadir("dumpster/dagmm_kddcup99_$(model_seed).bson"), results)
+
+
+### analysis
+using DataFrames, ValueHistories
+files = readdir(datadir("dumpster"), join=true)
+results = [load(f) for f in files]
+
+df = DataFrame(
+    "model_seed" => [parse(Int, split(split(f, '_')[end], '.')[1]) for f in files],
+    "niter" => [r[:niter] for r in results],
+    "precision" => [r[:precision] for r in results],
+    "recall" => [r[:recall] for r in results],
+    "f1" => [r[:f1] for r in results],
+    "auc" => [r[:auc] for r in results],
+    "threshold" => [r[:threshold] for r in results],
+)
+
+sort!(df, :niter)
+sort!(df, :auc)
+
+###


### PR DESCRIPTION
There is no original source code for this method. Extended https://github.com/mperezcarrasco/PyTorch-DAGMM to fit datasets other than KDDCUP. Compared performance on multiple runs with the same architecture yielding following results
```
    │ Row │ model_seed │ niter │ precision │ recall   │ f1       │ auc      │ threshold │
    ├─────┼────────────┼───────┼───────────┼──────────┼──────────┼──────────┼───────────┤
    │ 1   │ 843        │ 8760  │ 0.742011  │ 0.545673 │ 0.628874 │ 0.76224  │ -7.29858  │
    │ 2   │ 933        │ 6860  │ 0.786819  │ 0.604782 │ 0.683894 │ 0.778152 │ -7.15721  │
    │ 3   │ 116        │ 7340  │ 0.862177  │ 0.723329 │ 0.786673 │ 0.9147   │ -6.7746   │
    │ 4   │ 627        │ 7670  │ 0.8217    │ 0.663624 │ 0.73425  │ 0.916803 │ -5.60648  │
    │ 5   │ 499        │ 4560  │ 0.916522  │ 0.827299 │ 0.869628 │ 0.930591 │ -6.95185  │
    │ 6   │ 261        │ 7710  │ 0.85944   │ 0.72409  │ 0.78598  │ 0.931925 │ -6.42293  │
    │ 7   │ 761        │ 7180  │ 0.917163  │ 0.830177 │ 0.871505 │ 0.934966 │ -6.88933  │
    │ 8   │ 797        │ 6560  │ 0.940677  │ 0.875018 │ 0.90666  │ 0.944641 │ -7.52265  │
    │ 9   │ 498        │ 4380  │ 0.902527  │ 0.798968 │ 0.847596 │ 0.947122 │ -6.89145  │
    │ 10  │ 938        │ 14660 │ 0.896952  │ 0.792594 │ 0.84155  │ 0.949002 │ -6.74864  │
    │ 11  │ 555        │ 6880  │ 0.960658  │ 0.922737 │ 0.941316 │ 0.967731 │ -6.24293  │
    │ 12  │ 724        │ 14860 │ 0.872477  │ 0.744814 │ 0.803607 │ 0.970287 │ -3.81762  │
    │ 13  │ 214        │ 5020  │ 0.968746  │ 0.939966 │ 0.954139 │ 0.985249 │ -4.8568   │
    │ 14  │ 878        │ 14930 │ 0.970904  │ 0.943317 │ 0.956912 │ 0.988188 │ -4.18334  │
    │ 15  │ 532        │ 8280  │ 0.977635  │ 0.961636 │ 0.969569 │ 0.992474 │ -4.13328  │
    │ 16  │ 854        │ 11890 │ 0.974479  │ 0.953823 │ 0.96404  │ 0.99467  │ -2.07396  │
```
which show that the performance in the paper is attainable, but with high variance. More details on this is in `./test/models/dagmm.jl`.