### PR TITLE
REPEN

### DIFF
--- a/scripts/experiments_tabular/dagmm.jl
+++ b/scripts/experiments_tabular/dagmm.jl
@@ -28,26 +28,21 @@ modelname = "dagmm"
 
 function sample_params()
     parameter_rng = (
-        zdim 		= 2 .^(0:2),
+        zdim 		= 2 .^(0:1),
         hdim 		= 2 .^(1:8),
         nlayers 	= 2:3,
         ncomp       = 2:8,
-        lambda_rat 	= 1:2:9,
+        lambda_e 	= [1.0, 0.5, 0.1],
+        lambda_d    = [1.0, 0.5, 0.1, 0.05, 0.005],
         lr 			= [1f-3, 1f-4, 1f-5],
         batchsize 	= 2 .^ (5:8),
         activation	= ["tanh"],
         dropout		= 0.0:0.1:0.5,
-        wreg 		= [0.0, 1f-5, 1f-6],
+        wreg 		= [0.0],
         init_seed 	= 1:Int(1e8),
     )
-    parameters = (;zip(keys(parameter_rng), map(x->sample(x, 1)[1], parameter_rng))...)
-    
-    # ensure that zdim < hdim, even though zdim is usually small
-    while parameters.zdim >= parameters.hdim
-        @info "zdim $(parameters.zdim) too large in combination with hdim $(parameters.hdim)"
-		parameters = merge(parameters, (;zdim = sample(parameter_rng.zdim)))
-	end
-    parameters
+
+    (;zip(keys(parameter_rng), map(x->sample(x, 1)[1], parameter_rng))...)
 end
 
 function fit(data, parameters)

--- a/scripts/experiments_tabular/dagmm.jl
+++ b/scripts/experiments_tabular/dagmm.jl
@@ -32,7 +32,7 @@ function sample_params()
         hdim 		= 2 .^(1:8),
         nlayers 	= 2:3,
         ncomp       = 2:8,
-        lambda_rat 	= 1:9,
+        lambda_rat 	= 1:2:9,
         lr 			= [1f-3, 1f-4, 1f-5],
         batchsize 	= 2 .^ (5:8),
         activation	= ["tanh"],

--- a/scripts/experiments_tabular/dagmm.jl
+++ b/scripts/experiments_tabular/dagmm.jl
@@ -1,0 +1,119 @@
+using DrWatson
+@quickactivate
+using ArgParse
+using GenerativeAD
+using StatsBase: fit!, predict, sample
+using BSON
+using Flux
+
+s = ArgParseSettings()
+@add_arg_table! s begin
+    "max_seed"
+        default = 1
+        arg_type = Int
+        help = "maximum number of seeds to run through"
+    "dataset"
+        default = "iris"
+        arg_type = String
+        help = "dataset"
+    "contamination"
+        arg_type = Float64
+        help = "contamination rate of training data"
+        default = 0.0
+end
+parsed_args = parse_args(ARGS, s)
+@unpack dataset, max_seed, contamination = parsed_args
+
+modelname = "dagmm"
+
+function sample_params()
+    parameter_rng = (
+        zdim 		= 2 .^(0:2),
+        hdim 		= 2 .^(1:8),
+        nlayers 	= 1:3,
+        ncomp       = 2:8,
+        lambda_rat 	= 1:9,
+        lr 			= [1f-3, 1f-4, 1f-5],
+        batchsize 	= 2 .^ (5:8),
+        activation	= ["tanh"],
+        dropout		= 0.0:0.1:0.5,
+        wreg 		= [0.0, 1f-5, 1f-6],
+        init_seed 	= 1:Int(1e8),
+    )
+
+    (;zip(keys(parameter_rng), map(x->sample(x, 1)[1], parameter_rng))...)
+end
+
+function fit(data, parameters)
+    model = GenerativeAD.Models.DAGMM(;idim=size(data[1][1], 1), parameters...)
+
+    try
+        global info, fit_t, _, _, _ = @timed fit!(model, data; max_train_time=82800/max_seed, 
+                        patience=200, check_interval=1, parameters...)
+    catch e
+        @info "Failed training due to \n$e"
+        return (fit_t = NaN, history=nothing, npars=nothing, model=nothing), []
+    end
+
+    training_info = (
+        fit_t = fit_t,
+        history = info.history,
+        niter = info.niter,
+        npars = info.npars,
+        model = info.model
+        )
+
+    # compute mixture parameters from the whole training data
+    testmode!(model, true)
+    _, _, z, gamma = model(data[1][1])
+    phi, mu, cov = GenerativeAD.Models.compute_params(z, gamma)
+    testmode!(model, false)
+
+    # this will have to store the parameters obtained from clean data
+    training_info, [(x -> predict(info.model, x, phi, mu, cov), parameters)]
+end
+
+
+try_counter = 0
+max_tries = 10*max_seed
+cont_string = (contamination == 0.0) ? "" : "_contamination-$contamination"
+while try_counter < max_tries
+    parameters = sample_params()
+
+    for seed in 1:max_seed
+        savepath = datadir("experiments/tabular$cont_string/$(modelname)/$(dataset)/seed=$(seed)")
+        mkpath(savepath)
+
+        # get data
+        data = GenerativeAD.load_data(dataset, seed=seed, contamination=contamination)
+        edited_parameters = GenerativeAD.edit_params(data, parameters)
+
+        if GenerativeAD.check_params(savepath, edited_parameters)
+            @info "Started training $(modelname)$(edited_parameters) on $(dataset):$(seed)"
+            @info "Train/valdiation/test splits: $(size(data[1][1], 2)) | $(size(data[2][1], 2)) | $(size(data[2][1], 2))"
+            @info "Number of features: $(size(data[1][1], 1))"
+            
+            training_info, results = fit(data, edited_parameters)
+
+            if training_info.model != nothing
+                tagsave(joinpath(savepath, savename("model", edited_parameters, "bson", digits=5)), 
+                        Dict("model"=>training_info.model,
+                            "fit_t"=>training_info.fit_t,
+                            "history"=>training_info.history,
+                            "parameters"=>edited_parameters
+                            ), safe = true)
+                training_info = merge(training_info, (model = nothing,))
+            end
+            save_entries = merge(training_info, (modelname = modelname, seed = seed, dataset = dataset, contamination = contamination))
+
+            for result in results
+                GenerativeAD.experiment(result..., data, savepath; save_entries...)
+            end
+            global try_counter = max_tries + 1
+        else
+            @info "Model already present, trying new hyperparameters..."
+            global try_counter += 1
+        end
+    end
+end
+(try_counter == max_tries) ? (@info "Reached $(max_tries) tries, giving up.") : nothing

--- a/scripts/experiments_tabular/dagmm.jl
+++ b/scripts/experiments_tabular/dagmm.jl
@@ -85,7 +85,7 @@ function GenerativeAD.edit_params(data, parameters)
 	# set hdim ~ idim/2 if hdim >= idim
 	if parameters.hdim >= idim
 		hdims = 2 .^(1:8)
-		hdim_new = hdims[hdims .< idim//2][end]
+		hdim_new = hdims[hdims .<= (idim+1)//2][end]
         @info "Lowering width of autoencoder $(parameters.hdim) -> $(hdim_new)"
 		parameters = merge(parameters, (hdim=hdim_new,))
 	end

--- a/scripts/experiments_tabular/dagmm_run.sh
+++ b/scripts/experiments_tabular/dagmm_run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#SBATCH --time=24:00:00
+#SBATCH --nodes=1 --ntasks-per-node=4 --cpus-per-task=1
+#SBATCH --mem=24G
+#SBATCH --qos==collaborator
+
+MAX_SEED=$1
+DATASET=$2
+CONTAMINATION=$3
+
+module load Julia/1.5.3-linux-x86_64
+module load Python/3.8.2-GCCcore-9.3.0
+
+julia --project -e 'using Pkg; Pkg.instantiate();'
+
+julia --project ./dagmm.jl $MAX_SEED $DATASET $CONTAMINATION

--- a/scripts/experiments_tabular/dagmm_run.sh
+++ b/scripts/experiments_tabular/dagmm_run.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+#SBATCH --partition=cpu
 #SBATCH --time=24:00:00
-#SBATCH --nodes=1 --ntasks-per-node=4 --cpus-per-task=1
-#SBATCH --mem=24G
+#SBATCH --nodes=1 --cpus-per-task=1
+#SBATCH --mem=16G
 #SBATCH --qos==collaborator
 
 MAX_SEED=$1

--- a/scripts/experiments_tabular/repen.jl
+++ b/scripts/experiments_tabular/repen.jl
@@ -71,7 +71,7 @@ function fit(data, parameters)
 end
 
 function GenerativeAD.edit_params(data, parameters)
-    idim = size(data[1][1],1)
+    idim, n = size(data[1][1])
     # set hdim ~ idim/2 if hdim >= idim
     if parameters.nlayers > 1 && parameters.hdim >= idim
         hdims = 2 .^(1:8)
@@ -79,6 +79,23 @@ function GenerativeAD.edit_params(data, parameters)
         @info "Lowering width of embedding $(parameters.hdim) -> $(hdim_new)"
         parameters = merge(parameters, (hdim=hdim_new,))
     end
+
+    # modify batchsize to < n/3
+    if parameters.batchsize >= n//3
+        batchsizes = 2 .^(1:8)
+        batchsize_new = batchsizes[batchsizes .< n//3][end]
+        @info "Decreasing batchsize due to small number of samples $(parameters.batchsizes) -> $(batchsize_new)"
+        parameters = merge(parameters, (batchsize=batchsize_new,)) 
+    end
+
+    # modify subsample_size to < n
+    if parameters.subsample_size >= n
+        subsamples = 2 .^(1:8)
+        subsample_new = subsamples[subsamples .< n][end]
+        @info "Decreasing subsample_size due to small number of samples $(parameters.subsample_size) -> $(subsample_new)"
+        parameters = merge(parameters, (subsample_size=subsample_new,)) 
+    end
+
     parameters
 end
 

--- a/scripts/experiments_tabular/repen.jl
+++ b/scripts/experiments_tabular/repen.jl
@@ -30,13 +30,13 @@ function sample_params()
     parameter_rng = (
         zdim            = 2 .^(1:6),
         hdim            = 2 .^(1:8),
-        conf_margin     = 1000.0,
+        conf_margin     = 2 .^(9:11),
         nlayers         = 1:2,
         ensemble_size   = [25, 50]
         subsample_size  = 2 .^(1:8),
         batchsize       = 2 .^ (5:8),
         activation      = ["relu", "tanh"],
-        init_seed   = 1:Int(1e8),
+        init_seed       = 1:Int(1e8)
     )
     parameters = (;zip(keys(parameter_rng), map(x->sample(x, 1)[1], parameter_rng))...)
     

--- a/scripts/experiments_tabular/repen.jl
+++ b/scripts/experiments_tabular/repen.jl
@@ -1,0 +1,127 @@
+using DrWatson
+@quickactivate
+using ArgParse
+using GenerativeAD
+using StatsBase: fit!, predict, sample
+using BSON
+using Flux
+
+s = ArgParseSettings()
+@add_arg_table! s begin
+    "max_seed"
+        default = 1
+        arg_type = Int
+        help = "maximum number of seeds to run through"
+    "dataset"
+        default = "iris"
+        arg_type = String
+        help = "dataset"
+    "contamination"
+        arg_type = Float64
+        help = "contamination rate of training data"
+        default = 0.0
+end
+parsed_args = parse_args(ARGS, s)
+@unpack dataset, max_seed, contamination = parsed_args
+
+modelname = "repen"
+
+function sample_params()
+    parameter_rng = (
+        zdim            = 2 .^(1:6),
+        hdim            = 2 .^(1:8),
+        conf_margin     = 1000.0,
+        nlayers         = 1:2,
+        ensemble_size   = [25, 50]
+        subsample_size  = 2 .^(1:8),
+        batchsize       = 2 .^ (5:8),
+        activation      = ["relu", "tanh"],
+        init_seed   = 1:Int(1e8),
+    )
+    parameters = (;zip(keys(parameter_rng), map(x->sample(x, 1)[1], parameter_rng))...)
+    
+    # ensure that zdim < hdim
+    while parameters.zdim >= parameters.hdim
+        @info "zdim $(parameters.zdim) too large in combination with hdim $(parameters.hdim)"
+        parameters = merge(parameters, (;zdim = sample(parameter_rng.zdim)))
+    end
+    parameters
+end
+
+function fit(data, parameters)
+    model = GenerativeAD.Models.REPEN(;idim=size(data[1][1], 1), parameters...)
+
+    try
+        global info, fit_t, _, _, _ = @timed fit!(model, data; 
+                                max_train_time=82800/max_seed, parameters...)
+    catch e
+        @info "Failed training due to \n$e"
+        return (fit_t = NaN, history=nothing, npars=nothing, model=nothing), []
+    end
+
+    training_info = (
+        fit_t = fit_t,
+        history = info.history,
+        niter = info.niter,
+        npars = info.npars,
+        model = info.model
+        )
+
+    training_info, [(x -> predict(info.model, x; fit_data=data[1][1], parameters...), parameters)]
+end
+
+function GenerativeAD.edit_params(data, parameters)
+    idim = size(data[1][1],1)
+    # set hdim ~ idim/2 if hdim >= idim
+    if parameters.nlayers > 1 && parameters.hdim >= idim
+        hdims = 2 .^(1:8)
+        hdim_new = hdims[hdims .<= (idim+1)//2][end]
+        @info "Lowering width of embedding $(parameters.hdim) -> $(hdim_new)"
+        parameters = merge(parameters, (hdim=hdim_new,))
+    end
+    parameters
+end
+
+try_counter = 0
+max_tries = 10*max_seed
+cont_string = (contamination == 0.0) ? "" : "_contamination-$contamination"
+while try_counter < max_tries
+    parameters = sample_params()
+
+    for seed in 1:max_seed
+        savepath = datadir("experiments/tabular$cont_string/$(modelname)/$(dataset)/seed=$(seed)")
+        mkpath(savepath)
+
+        # get data
+        data = GenerativeAD.load_data(dataset, seed=seed, contamination=contamination)
+        edited_parameters = GenerativeAD.edit_params(data, parameters)
+
+        if GenerativeAD.check_params(savepath, edited_parameters)
+            @info "Started training $(modelname)$(edited_parameters) on $(dataset):$(seed)"
+            @info "Train/valdiation/test splits: $(size(data[1][1], 2)) | $(size(data[2][1], 2)) | $(size(data[2][1], 2))"
+            @info "Number of features: $(size(data[1][1], 1))"
+            
+            training_info, results = fit(data, edited_parameters)
+
+            if training_info.model != nothing
+                tagsave(joinpath(savepath, savename("model", edited_parameters, "bson", digits=5)), 
+                        Dict("model"=>training_info.model,
+                            "fit_t"=>training_info.fit_t,
+                            "history"=>training_info.history,
+                            "parameters"=>edited_parameters
+                            ), safe = true)
+                training_info = merge(training_info, (model = nothing,))
+            end
+            save_entries = merge(training_info, (modelname = modelname, seed = seed, dataset = dataset, contamination = contamination))
+
+            for result in results
+                GenerativeAD.experiment(result..., data, savepath; save_entries...)
+            end
+            global try_counter = max_tries + 1
+        else
+            @info "Model already present, trying new hyperparameters..."
+            global try_counter += 1
+        end
+    end
+end
+(try_counter == max_tries) ? (@info "Reached $(max_tries) tries, giving up.") : nothing

--- a/scripts/experiments_tabular/repen.jl
+++ b/scripts/experiments_tabular/repen.jl
@@ -120,7 +120,9 @@ while try_counter < max_tries
 
         # get data
         data = GenerativeAD.load_data(dataset, seed=seed, contamination=contamination)
-        edited_parameters = GenerativeAD.edit_params(data, parameters)
+        # edit_params is not deterministic and therefore `edited_parameters` may be different for each seed
+        # as a workaround once it is called it overwrites `parameters`, which should not be changed by the next call
+        parameters = edited_parameters = GenerativeAD.edit_params(data, parameters)
 
         if GenerativeAD.check_params(savepath, edited_parameters)
             @info "Started training $(modelname)$(edited_parameters) on $(dataset):$(seed)"
@@ -129,7 +131,7 @@ while try_counter < max_tries
             
             training_info, results = fit(data, edited_parameters)
 
-            if training_info.model != nothing
+            if training_info.model !== nothing
                 tagsave(joinpath(savepath, savename("model", edited_parameters, "bson", digits=5)), 
                         Dict("model"=>training_info.model,
                             "fit_t"=>training_info.fit_t,

--- a/scripts/experiments_tabular/repen_run.sh
+++ b/scripts/experiments_tabular/repen_run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#SBATCH --time=24:00:00
+#SBATCH --nodes=1 --ntasks-per-node=4 --cpus-per-task=1
+#SBATCH --mem=24G
+#SBATCH --qos==collaborator
+
+MAX_SEED=$1
+DATASET=$2
+CONTAMINATION=$3
+
+module load Julia/1.5.3-linux-x86_64
+module load Python/3.8.2-GCCcore-9.3.0
+
+julia --project -e 'using Pkg; Pkg.instantiate();'
+
+julia --project ./repen.jl $MAX_SEED $DATASET $CONTAMINATION

--- a/scripts/experiments_tabular/repen_run.sh
+++ b/scripts/experiments_tabular/repen_run.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+#SBATCH --partition=cpu
 #SBATCH --time=24:00:00
-#SBATCH --nodes=1 --ntasks-per-node=4 --cpus-per-task=1
-#SBATCH --mem=24G
+#SBATCH --nodes=1 --cpus-per-task=1
+#SBATCH --mem=12G
 #SBATCH --qos==collaborator
 
 MAX_SEED=$1

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -34,6 +34,7 @@ include("gan.jl")
 include("sptn.jl")
 include("loda.jl")
 include("dagmm.jl")
+include("repen.jl")
 
 # this contains dependencies from vae and aae
 include("utils/vae_utils.jl")

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -33,6 +33,7 @@ include("fanogan.jl")
 include("gan.jl")
 include("sptn.jl")
 include("loda.jl")
+include("dagmm.jl")
 
 # this contains dependencies from vae and aae
 include("utils/vae_utils.jl")

--- a/src/models/dagmm.jl
+++ b/src/models/dagmm.jl
@@ -1,3 +1,13 @@
+"""
+    Implements all needed parts for constructing DAGMM model
+        (https://sites.cs.ucsb.edu/~bzong/doc/iclr18-dagmm.pdf) for detecting anomalies.
+    Code is inspired by multiple reimplementations
+    - https://github.com/danieltan07/dagmm
+    - https://github.com/tnakae/DAGMM/
+    - https://github.com/Newcomer520/tf-dagmm
+    - https://github.com/mperezcarrasco/PyTorch-DAGMM
+"""
+
 using Flux: mse, softmax, unsqueeze, stack
 using LinearAlgebra
 using StatsBase

--- a/src/models/dagmm.jl
+++ b/src/models/dagmm.jl
@@ -4,6 +4,7 @@ using StatsBase
 using Statistics
 using Distributions
 using DistributionsAD
+using MLDataPattern: RandomBatches
 
 struct DAGMM{E,D,S}
     encoder::E
@@ -95,7 +96,7 @@ function compute_params(z, gamma)
     phi, mu, cov
 end
 
-function compute_energy(z, phi, mu, cov; eps=1e-12)
+function compute_energy(z, phi, mu, cov; eps=1e-7)
     T = eltype(z)
     z_mu = unsqueeze(z,2) .- mu
     D, K, _ = size(mu)

--- a/src/models/dagmm.jl
+++ b/src/models/dagmm.jl
@@ -163,15 +163,11 @@ function StatsBase.fit!(model::DAGMM, data::Tuple; max_train_time=82800,
     for batch in RandomBatches(X, batchsize)
         batch_loss = 0f0
 
-        grad_time = try 
-            @elapsed begin
-                gs = gradient(() -> begin 
-                    batch_loss = loss(trn_model, batch, λ₁, λ₂)
-                end, ps)
-                Flux.update!(opt, ps, gs)
-            end
-        catch
-            return trn_model, batch
+        grad_time = @elapsed begin
+            gs = gradient(() -> begin 
+                batch_loss = loss(trn_model, batch, λ₁, λ₂)
+            end, ps)
+            Flux.update!(opt, ps, gs)
         end
 
         push!(history, :batch_loss, i, batch_loss)

--- a/src/models/dagmm.jl
+++ b/src/models/dagmm.jl
@@ -1,0 +1,211 @@
+using Flux: mse, softmax, unsqueeze, stack
+using LinearAlgebra
+using StatsBase
+using Statistics
+using Distributions
+using DistributionsAD
+
+struct DAGMM{E,D,S}
+    encoder::E
+    decoder::D
+    estimator::S
+end
+
+Flux.@functor DAGMM
+
+function DAGMM(;idim::Int=1, activation="tanh", hdim=60, zdim=1, ncomp=2, 
+        nlayers::Int=3, dropout=0.5, init_seed=nothing, kwargs...)
+    # if seed is given, set it
+    (init_seed !== nothing) ? Random.seed!(init_seed) : nothing
+
+    encoder = build_mlp(idim, hdim, zdim, nlayers, activation=activation, lastlayer="linear")
+    decoder = build_mlp(zdim, hdim, idim, nlayers, activation=activation, lastlayer="linear")
+    estimator = build_mlp(zdim+2, hdim, ncomp, nlayers, activation=activation, lastlayer="linear")
+    
+    if dropout > 0.0
+        estimator = Chain(estimator[1:end-1]..., Dropout(dropout), estimator[end])
+    end
+
+    # reset seed
+    (init_seed !== nothing) ? Random.seed!() : nothing
+
+    DAGMM(encoder, decoder, estimator)
+end
+
+function Base.show(io::IO, model::DAGMM)
+    # to avoid the show explosion
+    print(io, "DAGMM(...)")
+end
+
+norm2(x; dims=1) = sqrt.(sum(abs2, x; dims=dims))
+
+function cosine_similarity(x₁, x₂; dims=1, eps=1e-8)
+    T = eltype(x₁)
+    nx₁ = norm2(x₁; dims=dims)
+    nx₂ = norm2(x₂; dims=dims)
+    sum(x₁ .* x₂; dims=dims) ./ max.(nx₁ .* nx₂, T(eps))
+end
+
+function compute_reconstruction(x, x̂)
+    relrec = norm2(x .- x̂; dims=1) ./ norm2(x; dims=1)
+    cosim = cosine_similarity(x, x̂; dims=1)
+    relrec, cosim
+end
+
+function (model::DAGMM)(x)
+    z_c = model.encoder(x)
+    x̂ = model.decoder(z_c)
+    rec_1, rec_2 = compute_reconstruction(x, x̂)
+    z = cat([z_c, rec_1, rec_2]..., dims=1)
+    gamma = softmax(model.estimator(z))
+    z_c, x̂, z, gamma
+end
+
+
+"""
+Computing the parameters phi, mu and gamma for sample energy function 
+
+K: number of Gaussian mixture components
+N: Number of samples
+D: Latent dimension
+
+z = DxN
+gamma = KxN
+
+this will be a little bit different in Julia
+""" 
+function compute_params(z, gamma)
+    #phi = D
+    gamma_sum = sum(gamma; dims=2)
+    phi = gamma_sum ./ size(gamma, 2)
+
+    #mu = D x K x 1
+    mu = sum(unsqueeze(gamma,1) .* unsqueeze(z,2); dims=3) ./ gamma_sum'
+
+    # z_mu = D x K x N
+    z_mu = unsqueeze(z,2) .- mu
+    
+    # z_mu = D x D x K x N
+    z_mu_z_mu_t = unsqueeze(z_mu, 2) .* unsqueeze(z_mu, 1)
+    
+    #cov = K x D x D
+    cov = sum(unsqueeze(unsqueeze(gamma, 1), 1) .* z_mu_z_mu_t; dims=4)
+    cov = dropdims(cov; dims=4) ./ unsqueeze(gamma_sum', 1)
+
+    phi, mu, cov
+end
+
+function compute_energy(z, phi, mu, cov; eps=1e-12)
+    T = eltype(z)
+    z_mu = unsqueeze(z,2) .- mu
+    D, K, _ = size(mu)
+
+    cov = cov .+ Diagonal(ones(Float32, D) .* T(eps))
+  
+    cov_inverse = stack([inv(cov[:,:,k]) for k in 1:K], 3)
+    det_cov = unsqueeze(unsqueeze([det(cov[:,:,k] .* 2 * T.(π)) for k in 1:K],1),1)
+    cov_diag = sum([sum(1 ./ diag(cov[:,:,k])) for k in 1:K])
+
+    E_z = -T(0.5) .* sum(sum(unsqueeze(z_mu, 1) .* cov_inverse, dims=2) .* unsqueeze(z_mu, 2), dims=1)
+    E_z = exp.(E_z)
+    E_z = -log.(sum(unsqueeze(phi', 1).* E_z ./ sqrt.(det_cov), dims=3).+ T(eps))
+          
+    E_z, cov_diag
+end
+
+
+function loss(model::DAGMM, x, λ₁, λ₂)
+    _, x̂, z, gamma = model(x)
+    reconst_loss = mse(x, x̂)
+    phi, mu, cov = compute_params(z, gamma)
+    sample_energy, cov_diag = compute_energy(z, phi, mu, cov)
+    reconst_loss + λ₁ * mean(sample_energy) + λ₂ * cov_diag
+end
+
+# during testing we use params fitted from training
+# testmode is not really necessary because dropout is not part if the autoencoder
+function StatsBase.predict(model::DAGMM, x, phi, mu, cov)
+    testmode!(model, true)
+    _, _, z, _ = model(x)
+    testmode!(model, false)
+    compute_energy(z, phi, mu, cov)[1]
+end
+
+
+function StatsBase.fit!(model::DAGMM, data::Tuple; max_train_time=82800,
+                        batchsize=64, patience=200, check_interval::Int=1, 
+                        wreg=1f-6, lambda_rat=1, lr=1f-4, kwargs...)
+    # add regularization through weight decay in optimizer
+    opt = (wreg > 0) ? ADAMW(lr, (0.9, 0.999), wreg) : Flux.ADAM(lr)
+    
+    trn_model = deepcopy(model)
+    ps = Flux.params(trn_model);
+
+    X = data[1][1]
+    # filter only normal data from validation set
+    X_val = data[2][1][:, data[2][2] .== 0.0f0]
+
+    # hardcoded parameters, changing only the ratios
+    λ₁, λ₂ = 0.1f0 * lambda_rat, 0.005f0 * lambda_rat
+
+    history = MVHistory()
+    _patience = patience
+    
+    best_val_loss = Inf
+    i = 1
+    start_time = time()
+    frmt(v) = round(v, digits=4)
+    for batch in RandomBatches(X, batchsize)
+        batch_loss = 0f0
+
+        grad_time = @elapsed begin
+            gs = gradient(() -> begin 
+                batch_loss = loss(trn_model, batch, λ₁, λ₂)
+            end, ps)
+            Flux.update!(opt, ps, gs)
+        end
+
+        push!(history, :batch_loss, i, batch_loss)
+        push!(history, :grad_time, i, grad_time)
+
+        if (i%check_interval == 0)
+            testmode!(trn_model, true)
+            val_loss_time = @elapsed val_loss = loss(trn_model, X_val, λ₁, λ₂)
+            testmode!(trn_model, false)
+
+            @info "$i - loss: $(frmt(batch_loss)) (batch) | $(frmt(val_loss)) (validation) || $(frmt(grad_time)) (t_grad) | $(frmt(val_loss_time)) (t_val)"
+            
+            if isnan(val_loss) || isinf(val_loss) || isnan(batch_loss) || isinf(batch_loss)
+                @info "Stopped training after $(i) iterations, $((time() - start_time)/3600) hours due to invalid values."
+                error("Encountered invalid values in loss function.")
+            end
+
+            push!(history, :validation_loss, i, val_loss)
+            push!(history, :val_loss_time, i, val_loss_time)
+
+            if val_loss < best_val_loss
+                best_val_loss = val_loss
+                _patience = patience
+
+                model = deepcopy(trn_model)
+            else # else stop if the model has not improved for `patience` iterations
+                _patience -= 1
+                if _patience == 0
+                    @info "Stopped training after $(i) iterations, $((time() - start_time)/3600) hours."
+                    break
+                end
+            end
+        end
+        
+        # time limit for training
+        if time() - start_time > max_train_time
+            @info "Stopped training after $(i) iterations, $((time() - start_time)/3600) hours due to time constraints."
+            model = deepcopy(trn_model)
+            break
+        end
+
+        i += 1
+    end
+
+    (history=history, niter=i, model=model, npars=sum(map(p->length(p), ps)))
+end

--- a/src/models/repen.jl
+++ b/src/models/repen.jl
@@ -46,12 +46,12 @@ end
 sqr_euclidean_dist(x,y; dims=1) = sum(abs2, x .- y, dims=dims)
 
 function ranking_loss(input_example, input_positive, input_negative;
-                        confidence_margin=1000.0)
+                        conf_margin=1000.0)
     T = eltype(input_example)
     positive_distances = sqr_euclidean_dist(input_example, input_positive)
     negative_distances = sqr_euclidean_dist(input_example, input_negative)
     
-    mean(max.(T(0.0), T(confidence_margin) .- (negative_distances .- positive_distances)))
+    mean(max.(T(0.0), T(conf_margin) .- (negative_distances .- positive_distances)))
 end
 
 # Is there something random in the way KDTree is created?
@@ -135,7 +135,7 @@ end
 
 function StatsBase.fit!(model::REPEN, data::Tuple; max_train_time=82800,
                         batchsize=64, max_iters=10000, check_interval::Int=10, 
-                        confidence_margin=1000.0, kwargs...)
+                        conf_margin=1000.0, kwargs...)
     
     opt = ADADelta()
     ps = Flux.params(model);
@@ -153,7 +153,7 @@ function StatsBase.fit!(model::REPEN, data::Tuple; max_train_time=82800,
         grad_time = @elapsed begin
             gs = gradient(ps) do
                 z_triplet = model(batch)
-                batch_loss = ranking_loss(z_triplet...; confidence_margin=confidence_margin)
+                batch_loss = ranking_loss(z_triplet...; conf_margin=conf_margin)
             end
             Flux.update!(opt, ps, gs)
         end

--- a/src/models/repen.jl
+++ b/src/models/repen.jl
@@ -54,7 +54,6 @@ function ranking_loss(input_example, input_positive, input_negative;
     mean(max.(T(0.0), T(conf_margin) .- (negative_distances .- positive_distances)))
 end
 
-# Is there something random in the way KDTree is created?
 function lesinn(xq; fit_data=xq, ensemble_size=50, subsample_size=8, kwargs...)
     Random.seed!(42) 
     n = size(fit_data, 2)
@@ -73,15 +72,15 @@ function cutoff_unsorted(vals; th0=1.7321)
     v_mean = mean(vals)
     v_std = std(vals)
     th = v_mean + th0 * v_std 
-    if th >= maximum(vals)
+    if th >= maximum(vals) # return the top-10 outlier scores
         temp = sort(vals)
-        th = temp[-11]
+        th = temp[end-10]
     end
 
     outlier_ind = findall(vals .> th)
     inlier_ind = findall(vals .<= th)
     
-    inlier_ind, outlier_ind;
+    inlier_ind, outlier_ind
 end
 
 

--- a/src/models/repen.jl
+++ b/src/models/repen.jl
@@ -1,0 +1,183 @@
+"""
+    Implements all needed parts for constructing REPEN model
+        (http://arxiv.org/abs/1806.04808) for detecting anomalies.
+    Code is inspired by original Keras implementation 
+    https://github.com/GuansongPang/deep-outlier-detection
+    https://github.com/Ryosaeba8/Anomaly_detection/tree/master/REPEN
+"""
+
+using Random
+using Statistics
+using StatsBase: sample, predict, fit!, Weights
+using NearestNeighbors: KDTree, knn, Euclidean
+using Flux
+
+struct REPEN{E}
+    e::E
+end
+
+Flux.@functor REPEN
+
+function REPEN(;idim::Int=1, activation="relu", hdim=40, 
+                zdim=20, nlayers::Int=1, init_seed=nothing, kwargs...)
+    # if seed is given, set it
+    (init_seed !== nothing) ? Random.seed!(init_seed) : nothing
+
+    e = build_mlp(idim, hdim, zdim, nlayers, activation=activation)
+    
+    # reset seed
+    (init_seed !== nothing) ? Random.seed!() : nothing
+
+    REPEN(e)
+end    
+
+function (m::REPEN)(x::Tuple)
+    @assert length(x) == 3
+    examples, positive, negative = x
+    m.e(examples), m.e(positive), m.e(negative)
+end
+
+function Base.show(io::IO, model::REPEN)
+    print(io, "REPEN(")
+    print(io, model.e)
+    print(io, ")")
+end
+
+sqr_euclidean_dist(x,y; dims=1) = sum(abs2, x .- y, dims=dims)
+
+function ranking_loss(input_example, input_positive, input_negative;
+                        confidence_margin=1000.0)
+    T = eltype(input_example)
+    positive_distances = sqr_euclidean_dist(input_example, input_positive)
+    negative_distances = sqr_euclidean_dist(input_example, input_negative)
+    
+    mean(max.(T(0.0), T(confidence_margin) .- (negative_distances .- positive_distances)))
+end
+
+# Is there something random in the way KDTree is created?
+function lesinn(xq; fit_data=xq, ensemble_size=50, subsample_size=8, kwargs...)
+    Random.seed!(42) 
+    n = size(fit_data, 2)
+    scores = zeros(Float32, size(xq, 2))
+    for i in 1:ensemble_size
+        subsample = fit_data[:, randperm(n)[1:subsample_size]]
+        kdt = KDTree(subsample, Euclidean(); leafsize = 40)
+        _, dists = knn(kdt, xq, 1)
+        scores .+= getindex.(dists, 1)
+    end
+    Random.seed!() 
+    scores ./ ensemble_size
+end
+
+function cutoff_unsorted(vals; th0=1.7321)
+    v_mean = mean(vals)
+    v_std = std(vals)
+    th = v_mean + th0 * v_std 
+    if th >= maximum(vals)
+        temp = sort(vals)
+        th = temp[-11]
+    end
+
+    outlier_ind = findall(vals .> th)
+    inlier_ind = findall(vals .<= th)
+    
+    inlier_ind, outlier_ind;
+end
+
+
+function triplet_batch_generation(X, outlier_scores; batchsize=256)
+    inlier_ids, outlier_ids = cutoff_unsorted(outlier_scores)
+    nin, nout = length(inlier_ids), length(outlier_ids)
+    
+    transforms = sum(outlier_scores[inlier_ids]) .- outlier_scores[inlier_ids]
+    total_weights_p = sum(transforms)
+    positive_weights = transforms ./ total_weights_p
+    
+    total_weights_n = sum(outlier_scores[outlier_ids])
+    negative_weights = outlier_scores[outlier_ids] ./ total_weights_n
+    
+    examples_ids = zeros(Int, batchsize)
+    positives_ids = zeros(Int, batchsize)
+    negatives_ids = zeros(Int, batchsize)
+    
+    for i in 1:batchsize
+        sid = sample(1:nin, Weights(positive_weights))
+        examples_ids[i] = inlier_ids[sid]
+        
+        sid2 = sample(1:nin)
+        
+        while sid2 == sid
+            sid2 = sample(1:nin)
+        end
+        positives_ids[i] = inlier_ids[sid2]
+
+        sid = sample(1:nin, Weights(negative_weights))
+        negatives_ids[i] = outlier_ids[sid]
+    end
+    
+    X[:, examples_ids], X[:, positives_ids], X[:, negatives_ids]
+end
+
+
+"""
+    function StatsBase.predict(model::REPEN, xq; fit_data=xq, ensemble_size=50, subsample_size=8)
+
+Computes LESINN score by constructing KDTree over subsamples of *projected* 
+training data `fit_data` and predicts on *projected* query points `xq` using 1NN.
+"""
+function StatsBase.predict(model::REPEN, xq; fit_data=xq, ensemble_size=50, subsample_size=8, kwargs...)
+    zq = model.e(xq)
+    zfit = model.e(fit_data)
+
+    lesinn(zq; fit_data=zfit, ensemble_size=ensemble_size, subsample_size=subsample_size)
+end
+
+
+function StatsBase.fit!(model::REPEN, data::Tuple; max_train_time=82800,
+                        batchsize=64, max_iters=10000, check_interval::Int=10, 
+                        confidence_margin=1000.0, kwargs...)
+    
+    opt = ADADelta()
+    ps = Flux.params(model);
+
+    X = data[1][1]
+    outlier_scores = lesinn(X; kwargs...)
+    history = MVHistory()
+
+    start_time = time()
+    frmt(v) = round(v, digits=4)
+    for i in 1:max_iters
+        batch_loss = 0f0
+        sample_time = @elapsed batch = triplet_batch_generation(X, outlier_scores; batchsize=batchsize)
+
+        grad_time = @elapsed begin
+            gs = gradient(ps) do
+                z_triplet = model(batch)
+                batch_loss = ranking_loss(z_triplet...; confidence_margin=confidence_margin)
+            end
+            Flux.update!(opt, ps, gs)
+        end
+
+        push!(history, :batch_loss, i, batch_loss)
+        push!(history, :grad_time, i, grad_time)
+
+        if isnan(batch_loss) || isinf(batch_loss)
+            @info "Stopped training after $(i) iterations, $((time() - start_time)/3600) hours due to invalid values."
+            error("Encountered invalid values in loss function.")
+        end
+
+        if (i%check_interval == 0)
+            @info "$i - loss: $(frmt(batch_loss)) (batch) | $(frmt(sample_time)) (t_batchgen) | $(frmt(grad_time)) (t_grad)"
+        end
+        
+        # time limit for training
+        if time() - start_time > max_train_time
+            @info "Stopped training after $(i) iterations, $((time() - start_time)/3600) hours due to time constraints."
+            model = deepcopy(model)
+            break
+        end
+
+    end
+
+    (history=history, niter=max_iters, model=model, npars=sum(map(p->length(p), ps)))
+end

--- a/test/models/dagmm.jl
+++ b/test/models/dagmm.jl
@@ -1,0 +1,118 @@
+###
+# using Revise
+###
+using DrWatson
+using GenerativeAD
+using StatsBase: fit!, predict, sample
+using Statistics
+using BSON
+using Flux
+using NPZ
+using Random
+
+parameters = (
+    lambda_rat 	= 1,
+    lr 			= 1f-4,
+    batchsize 	= 1024,
+    wreg 		= 0.0,
+)
+
+# loading KDDCUP data from npz file
+file = datadir("kdd_cup.npz") # taken from https://github.com/mperezcarrasco/PyTorch-DAGMM
+pydata = NPZ.npzread(file)
+
+labels = pydata["kdd"][:, end];
+features = copy(pydata["kdd"][:, 1:end-1]')
+
+normal_data = features[:, labels .== 0];
+anomalous_data = features[:, labels .== 1];
+
+# split data with fixed seed
+data = GenerativeAD.Datasets.train_val_test_split(normal_data, anomalous_data; seed=1)
+idim = size(data[1][1], 1)
+
+# when running in batch randomize model seed (reset after training - deterministic random batches)
+model_seed = rand(1:1000)
+Random.seed!(model_seed);
+encoder = Chain(Dense(idim, 60, tanh), Dense(60, 30, tanh), Dense(30, 10, tanh), Dense(10, 1))
+decoder = Chain(Dense(1, 10, tanh), Dense(10, 30, tanh), Dense(30, 60, tanh), Dense(60, idim))
+estimator = Chain(Dense(3, 10, tanh), Dropout(0.5), Dense(10, 4))
+
+model = GenerativeAD.Models.DAGMM(encoder, decoder, estimator)
+info, fit_t, _, _, _ = @timed fit!(model, data; patience=20, check_interval=10, parameters...)
+Random.seed!()
+
+trained_model = info.model
+
+testmode!(trained_model, true)
+_, _, z, gamma = trained_model(data[1][1])
+phi, mu, cov = GenerativeAD.Models.compute_params(z, gamma)
+testmode!(trained_model, false)
+
+trn_scores = predict(trained_model, data[1][1], phi, mu, cov);
+val_scores = predict(trained_model, data[2][1], phi, mu, cov);
+tst_scores = predict(trained_model, data[3][1], phi, mu, cov);
+
+using EvalMetrics: ConfusionMatrix, recall, precision, f1_score, roccurve, auc_trapezoidal
+
+# test only
+threshold = quantile(vcat(trn_scores, val_scores, tst_scores), 0.8)
+# threshold = quantile(vcat(trn_scores, val_scores), 0.8)
+
+tst_ŷ = tst_scores .> threshold;
+cm = ConfusionMatrix(data[3][2], tst_ŷ)
+rec, prc, f1s = recall(cm), precision(cm), f1_score(cm)
+
+roc = roccurve(data[3][2], tst_scores)
+auc = auc_trapezoidal(roc)
+
+
+# test + validation
+# val_ŷ = val_scores .> threshold;
+# cm = ConfusionMatrix(vcat(data[2][2], data[3][2]), vcat(val_ŷ, tst_ŷ))
+# recall(cm), precision(cm), f1_score(cm)
+
+results = Dict(
+    :history    => info.history,
+    :niter      => info.niter,
+    :model      => info.model,
+    :recall     => rec,
+    :precision  => prc,
+    :f1         => f1s,
+    :auc        => auc,
+    :phi        => phi, 
+    :mu         => mu,
+    :cov        => cov,
+    :threshold  => threshold,
+    :trn_scores => trn_scores,
+    :trn_labels => data[1][2],
+    :val_scores => val_scores,
+    :val_labels => data[2][2],
+    :tst_scores => tst_scores,
+    :tst_labels => data[3][2]
+)
+
+@info("", model_seed, threshold, rec, prc, f1s, auc)
+
+save(datadir("dumpster/dagmm_kddcup99_$(model_seed).bson"), results)
+
+
+### analysis
+using DataFrames, ValueHistories
+files = readdir(datadir("dumpster"), join=true)
+results = [load(f) for f in files]
+
+df = DataFrame(
+    "model_seed" => [parse(Int, split(split(f, '_')[end], '.')[1]) for f in files],
+    "niter" => [r[:niter] for r in results],
+    "precision" => [r[:precision] for r in results],
+    "recall" => [r[:recall] for r in results],
+    "f1" => [r[:f1] for r in results],
+    "auc" => [r[:auc] for r in results],
+    "threshold" => [r[:threshold] for r in results],
+)
+
+sort!(df, :niter)
+sort!(df, :auc)
+
+###

--- a/test/models/repen.jl
+++ b/test/models/repen.jl
@@ -1,0 +1,88 @@
+using Revise
+
+using DrWatson
+using GenerativeAD
+using StatsBase: fit!, predict, sample
+using Statistics
+using BSON
+using Flux
+using DataFrames, CSV
+using Random
+using EvalMetrics: ConfusionMatrix, recall, precision, f1_score, roccurve, auc_trapezoidal
+
+for dataset in ["probe", "secom", "u2r"]
+    for subsample in 2 .^(3:8)
+        parameters = (
+            confidence_margin  = 1000.0,
+            batchsize 	       = 256,
+            zdim               = 20,
+            nlayers            = 1,
+            hdim               = 10, # does not matter with one layer
+            activation         = "relu",
+            ensemble_size      = 50,
+            subsample_size     = 16,
+            init_seed          = 42
+        )
+
+        parameters = merge(parameters, (;subsample_size=subsample))
+
+        # loading data from RDP paper https://github.com/billhhh/RDP/tree/master/RDP-Anomaly/data
+        file = datadir("rdp_datasets/$(dataset).csv")
+        df = CSV.read(file);
+
+        labels = Int.(df[:class]);
+        features = Float32.(copy(Matrix(select(df, Not(:class)))'));
+
+        data = ((features, labels),)
+        idim = size(data[1][1], 1)
+
+        @info "Started training REPEN$(parameters) on $(dataset)"
+        @info "Number of data points : $(size(data[1][1], 2))"
+        @info "Number of features: $(size(data[1][1], 1))"
+
+        model = GenerativeAD.Models.REPEN(;idim=idim, parameters...)
+        try
+            global info, fit_t, _, _, _ = @timed fit!(model, data; parameters...)
+        catch e
+            @warn "Training failed due to $e. Continuing."
+            continue
+        end
+
+        lesinn_trn_scores = GenerativeAD.Models.lesinn(data[1][1]; fit_data=data[1][1], parameters...);
+        trn_scores = predict(model, data[1][1]; fit_data=data[1][1], parameters...);
+
+        auc = roccurve(data[1][2], trn_scores) |> auc_trapezoidal
+        lesinn_auc = roccurve(data[1][2], lesinn_trn_scores) |> auc_trapezoidal
+
+        @info("", dataset, subsample, auc, lesinn_auc)
+
+        results = Dict(
+            :dataset        => dataset,
+            :modelname      => "REPEN",
+            :history        => info.history,
+            :model          => info.model,
+            :auc            => auc,
+            :lesinn_auc     => lesinn_auc,
+            :trn_scores     => trn_scores,
+            :trn_labels     => data[1][2],
+            :parameters     => parameters,
+            :subsample_size => parameters.subsample_size
+        )
+
+        wsave(datadir("dumpster/repen/$(dataset)_$(subsample).bson"), results)
+    end
+end
+
+### analysis
+using DataFrames, ValueHistories, CSV.SentinelArrays
+files = readdir(datadir("dumpster/repen"), join=true)
+results = [load(f) for f in files]
+
+df = DataFrame(
+    "dataset" => [r[:dataset] for r in results],
+    "subsample" => [r[:subsample_size] for r in results],
+    "auc" => [r[:auc] for r in results],
+    "lesinn_auc" => [r[:lesinn_auc] for r in results]
+)
+
+sort(df, (:dataset, :auc))

--- a/test/models/repen.jl
+++ b/test/models/repen.jl
@@ -10,11 +10,11 @@ using DataFrames, CSV
 using Random
 using EvalMetrics: ConfusionMatrix, recall, precision, f1_score, roccurve, auc_trapezoidal
 
-for dataset in ["probe", "secom", "u2r"]
+for dataset in ["ad_cat", "apascal", "bank-additional-full_normalised", "lung-1vs5", "probe", "secom", "u2r"]
     for subsample in 2 .^(3:8)
         parameters = (
             confidence_margin  = 1000.0,
-            batchsize 	       = 256,
+            batchsize          = 256,
             zdim               = 20,
             nlayers            = 1,
             hdim               = 10, # does not matter with one layer


### PR DESCRIPTION
Extended original code for this method from https://github.com/GuansongPang/deep-outlier-detection . Tested on some datasets from RDP method for anomaly detection https://github.com/billhhh/RDP/tree/master/RDP-Anomaly/data + added AD dataset with categorical features only from https://archive.ics.uci.edu/ml/machine-learning-databases/internet_ads/ . Performance is on par with original REPEN paper (AD and LC datasets) and exceeds those reported in the RDP paper often by large margin. The test code is stored in `./test/models/repen.jl`. Only the subsample size has been optimized, other hyperparameters have been set to defaults.
```
│ Row │ dataset                         │ subsample │ auc      │ lesinn_auc │
├─────┼─────────────────────────────────┼───────────┼──────────┼────────────┤
│ 6   │ ad_cat                          │ 64        │ 0.876987 │ 0.767399   │
│ 12  │ apascal                         │ 256       │ 0.888722 │ 0.796571   │
│ 18  │ bank-additional-full_normalised │ 8         │ 0.695318 │ 0.6908     │
│ 24  │ lung-1vs5                       │ 4         │ 0.916667 │ 0.901079   │
│ 30  │ probe                           │ 16        │ 0.995974 │ 0.996301   │
│ 36  │ secom                           │ 64        │ 0.551324 │ 0.548373   │
│ 42  │ u2r                             │ 256       │ 0.983533 │ 0.98635    │
``` 

Rebased on DAGMM branch, which should be merged before this branch.